### PR TITLE
Fix canonical pages

### DIFF
--- a/_includes/global_metadata.html
+++ b/_includes/global_metadata.html
@@ -14,8 +14,11 @@
 <meta name="author" content="{% if page.author %} {{ page.author }} {{else}} {{ site.author }} {% endif %}" />
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
 <meta name="theme-color" content="#204f9e" />
+{{ if page.alternative }}
 <link rel="canonical" href="{{ page.url | absolute_url }}" />
+{{ endif }}
 <title>{% if page.title %} {{ page.title }} {% else %} {{site.title}} {% endif %}</title>
+
 
 <!-- Open Graph Facebook-->
 <meta property="og:title" content="{% if page.title %} {{ page.title }} {% else %} {{ site.title }} {% endif %}" />

--- a/_includes/global_metadata.html
+++ b/_includes/global_metadata.html
@@ -14,9 +14,9 @@
 <meta name="author" content="{% if page.author %} {{ page.author }} {{else}} {{ site.author }} {% endif %}" />
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
 <meta name="theme-color" content="#204f9e" />
-{{ if page.alternative }}
+{% if page.alternative %}
 <link rel="canonical" href="{{ page.url | absolute_url }}" />
-{{ endif }}
+{% endif %}
 <title>{% if page.title %} {{ page.title }} {% else %} {{site.title}} {% endif %}</title>
 
 


### PR DESCRIPTION
**Context**
Web developers are advised to [add a canonical link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?sjid=4524266207393007850-SA&visit_id=638294073269135559-3866903194&rd=1&hl=pt-br#rel-canonical-link-method) to pages that are alternatives to another one. Previously we had added this tag to the main version of a page.

**Problem**
Google Search Console seems to be removing pages with a canonical tag from Google's index, 

**Solution**
We adjusted the code so that the canonical link is added to pages that are, in fact, alternatives.